### PR TITLE
Fix/dropdown not picking selected option on separate state

### DIFF
--- a/src/core/util.tsx
+++ b/src/core/util.tsx
@@ -40,14 +40,14 @@ export function mergeDicts(dict1, dict2) {
   return { ...dict1, ...dict2, ...mergedDict }
 }
 
-export function checkState(stateString: string, props: any, initValue = {}) {
+export function checkState(stateString: string, props: any) {
   const propKeys = Object.keys(props)
   const setStateString = `set${
     stateString.charAt(0).toUpperCase() + stateString.slice(1)
   }`
 
   if (!propKeys.includes(stateString) || !propKeys.includes(setStateString)) {
-    const [state, setState] = useState(initValue)
+    const [state, setState] = useState()
     props[stateString] = props[stateString] || state
     props[setStateString] = props[setStateString] || setState
   }


### PR DESCRIPTION
1. Problem
The dropdown does not pick up the selected option when the state is given separately

2. Possible reason
If a specific getter and a setter are present, it does not set any value

3. Possible Solution
Modify the checkState function to remove the initValue then check if a given state variable and its corresponding update function exist in the props object. If they do not exist, the function will initialize them with the useState hook and sets their default values to an empty object