### PR TITLE
table tooltip documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -542,13 +542,11 @@ React table component to conveniently display out-of-the-box data.
 ### Table sortArgs Passthrough
 
 The sortArgs are the arguments used to decide how the table should be sorted.
-These arguments are passed through the setConfig which is a state varable used to manage the column,ascending and sortFn properties which have been explained in the useSort hook
+These arguments are passed through the setConfig which is a state variable used to manage the column, ascending and sortFn properties which have been explained in the useSort hook
 
-### Table tooltip ###
+### Table Tooltip ###
 
-The Tooltip is originally set as a constant variable for display of custom value on point/hover. However, in the case of a filter being applied, no tooltip value is displayed. 
- 
-This is a re-render issue as Tooltips have to be a stateful variable instead a constant. Hence, best solution to apply is to use a useState hook to enable a re-render of the component with the applied filter.
+Make sure the tooltip is a stateful variable rather than constant, as when it is set as a constant variable no tooltip can be displayed after partial re-rendering (e.g. filtering). 
 
 ### Table Example
 


### PR DESCRIPTION
**Problem**
1. Re-render issue. The tooltip fails to display value upon a change in a filter.

**Possible reason**
1. The tooltip has to be a stateful variable instead a constant as using the constant variable prevents a re-render of the component.

**Possible solution**
1. Added guidelines to documentation explaining how best to approach the problem.