### PR TITLE
Feature/46 add onload event to library

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Common events currently include:
 - move: onMove -> usually sets point state
 - search: onSearch -> triggers whenever the search value changes (for dropdown)
 - leave: onLeave -> triggers when the mouse leaves a component
+- load: onLoad -> triggers when the object is fully rendered for the first time. For Map, Chart, and other components with loading animations: fires when object is first rendered rather than after the animation. For Dropdown components: fires when dropdown button is first loaded, does not fire during or after input selection.
 
 To register your own event, pass a list of subscribers in the prop of any component.
 

--- a/src/core/eventManager.tsx
+++ b/src/core/eventManager.tsx
@@ -34,5 +34,6 @@ export const useEventManagement = ({
     onMove: generateHandler("move"),
     onSearch: generateHandler("search"),
     onLeave: generateHandler("leave"),
+    onLoad: generateHandler("load")
   }
 }

--- a/src/core/wrapper.tsx
+++ b/src/core/wrapper.tsx
@@ -53,14 +53,14 @@ export const Wrapper = ({
   const handlers = useEventManagement({ subscribers })
 
   const id = useId()
-  const { OnLoadWrapper } = useOnLoad({
+
+  useOnLoad({
     onLoad: handlers["onLoad"],
     id: props?.key || id,
-    ...containerProps,
   })
 
   return (
-    <OnLoadWrapper>
+    <div {...containerProps} key={props?.key}>
       <Component {...props} {...handlers} />
       {enableDownload && (
         <DownloadElement
@@ -75,6 +75,6 @@ export const Wrapper = ({
           }
         />
       )}
-    </OnLoadWrapper>
+    </div>
   )
 }

--- a/src/core/wrapper.tsx
+++ b/src/core/wrapper.tsx
@@ -54,7 +54,7 @@ export const Wrapper = ({
   const id = useId()
 
   return (
-    <MyDiv {...containerProps} id={props?.key || id} onLoad={handlers["onLoad"]}>
+    <CustomDiv {...containerProps} id={props?.key || id} onLoad={handlers["onLoad"]}>
       <Component {...props} {...handlers}/>
       {enableDownload && (
         <DownloadElement
@@ -69,7 +69,7 @@ export const Wrapper = ({
           }
         />
       )}
-    </MyDiv>
+    </CustomDiv>
   )
 }
 
@@ -83,8 +83,7 @@ function runAfterFramePaint(callback) {
   });
 }
 
-
-const MyDiv = ({ onLoad, children, id,  ...props }) => {
+const CustomDiv = ({ onLoad, children, id,  ...props }) => {
     
   // Queues a requestAnimationFrame and onmessage
   runAfterFramePaint(() => {

--- a/src/core/wrapper.tsx
+++ b/src/core/wrapper.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useContext, useId } from "react"
+import React, { memo, useContext, useEffect, useId } from "react"
 
 import { useEventManagement } from "./eventManager"
 import { useStateListener } from "./stateListener"
@@ -74,22 +74,20 @@ export const Wrapper = ({
 }
 
 
-// Finished renderring check.
 function runAfterFramePaint(callback) {
   requestAnimationFrame(() => {
       const messageChannel = new MessageChannel();
       messageChannel.port1.onmessage = callback;
-      messageChannel.port2.postMessage("Finished loading");
+      messageChannel.port2.postMessage(undefined);
   });
 }
 
-const CustomDiv = ({ onLoad, children, id,  ...props }) => {
-    
-  // Queues a requestAnimationFrame and onmessage
-  runAfterFramePaint(() => {
-      // Set a performance mark shortly after the frame has been produced.
-      onLoad()
-  });
+const CustomDiv = ({ onLoad, children, id, ...props }) => {
+  useEffect(() => {
+    runAfterFramePaint(() => {
+        onLoad()
+    })
+  }, [])
 
   return <div {...props} key={id}>{children}</div>
 } 

--- a/src/core/wrapper.tsx
+++ b/src/core/wrapper.tsx
@@ -5,6 +5,7 @@ import { useStateListener } from "./stateListener"
 import { mergeDicts } from "./util"
 import { ComponentContext } from "./context"
 import { iWrapper, iReactive } from "./interface"
+import { useOnLoad } from "../hooks"
 import {
   DownloadElement,
   downloadDefaults,
@@ -52,10 +53,15 @@ export const Wrapper = ({
   const handlers = useEventManagement({ subscribers })
 
   const id = useId()
+  const { OnLoadWrapper } = useOnLoad({
+    onLoad: handlers["onLoad"],
+    id: props?.key || id,
+    ...containerProps,
+  })
 
   return (
-    <CustomDiv {...containerProps} id={props?.key || id} onLoad={handlers["onLoad"]}>
-      <Component {...props} {...handlers}/>
+    <OnLoadWrapper>
+      <Component {...props} {...handlers} />
       {enableDownload && (
         <DownloadElement
           name={name}
@@ -69,25 +75,6 @@ export const Wrapper = ({
           }
         />
       )}
-    </CustomDiv>
+    </OnLoadWrapper>
   )
 }
-
-
-function runAfterFramePaint(callback) {
-  requestAnimationFrame(() => {
-      const messageChannel = new MessageChannel();
-      messageChannel.port1.onmessage = callback;
-      messageChannel.port2.postMessage(undefined);
-  });
-}
-
-const CustomDiv = ({ onLoad, children, id, ...props }) => {
-  useEffect(() => {
-    runAfterFramePaint(() => {
-        onLoad()
-    })
-  }, [])
-
-  return <div {...props} key={id}>{children}</div>
-} 

--- a/src/hooks.tsx
+++ b/src/hooks.tsx
@@ -1,3 +1,4 @@
 export * from "./hooks/useDim"
 export * from "./hooks/useSort"
 export * from "./hooks/useSearch"
+export * from "./hooks/useOnLoad"

--- a/src/hooks/useOnLoad.tsx
+++ b/src/hooks/useOnLoad.tsx
@@ -1,0 +1,32 @@
+import React, { useEffect } from "react"
+
+export const useOnLoad = ({
+  onLoad,
+  children,
+  id,
+  ...props
+}: {
+  onLoad?: Function
+  children: React.ReactNode
+  id: string
+}) => {
+  useEffect(() => {
+    runAfterFramePaint(onLoad)
+  }, [])
+  const OnLoadWrapper = () => {
+    return (
+      <div {...props} key={id}>
+        {children}
+      </div>
+    )
+  }
+  return { OnLoadWrapper }
+}
+
+function runAfterFramePaint(callback) {
+  requestAnimationFrame(() => {
+    const messageChannel = new MessageChannel()
+    messageChannel.port1.onmessage = callback
+    messageChannel.port2.postMessage(undefined)
+  })
+}

--- a/src/hooks/useOnLoad.tsx
+++ b/src/hooks/useOnLoad.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react"
+import React, { useEffect } from "react"
 
 export const useOnLoad = ({
   onLoad,

--- a/src/hooks/useOnLoad.tsx
+++ b/src/hooks/useOnLoad.tsx
@@ -1,26 +1,15 @@
-import React, { useEffect } from "react"
+import React, { useEffect, useState } from "react"
 
 export const useOnLoad = ({
   onLoad,
-  children,
   id,
-  ...props
 }: {
   onLoad?: Function
-  children: React.ReactNode
   id: string
 }) => {
   useEffect(() => {
     runAfterFramePaint(onLoad)
   }, [])
-  const OnLoadWrapper = () => {
-    return (
-      <div {...props} key={id}>
-        {children}
-      </div>
-    )
-  }
-  return { OnLoadWrapper }
 }
 
 function runAfterFramePaint(callback) {


### PR DESCRIPTION
Added onLoad() functionality and documentation (incl. caveats) related to its usage. 

Goal: add subscribers with functions that run after a component has fully loaded.

WIP: verification whether it indeed fires after the loading