### PR TITLE
refactoring tooltip to row-flow and allowing for customTooltipData

### DIFF
--- a/src/components/Map/mapConfig.tsx
+++ b/src/components/Map/mapConfig.tsx
@@ -21,6 +21,7 @@ export const defaults = {
       },
       style: {
         display: "flex",
+        flexDirection: "column",
         position: "absolute",
         width: "fit-content",
         gap: "0.5rem",
@@ -45,6 +46,15 @@ export const defaults = {
           borderWidth: "0.3rem",
           borderStyle: "solid",
           borderColor: "transparent #1F456E transparent transparent",
+        },
+      },
+      title: { style: { textAlign: "center", textTransform: "capitalize" } },
+      content: {
+        style: {
+          display: "flex",
+          alignItems: "flex-start",
+          justifyContent: "space-between",
+          gap: "0.5rem",
         },
       },
       label: {

--- a/src/components/Map/mapTooltip.tsx
+++ b/src/components/Map/mapTooltip.tsx
@@ -36,17 +36,36 @@ export const renderTooltip = ({
 }: iTooltipRenderer): JSX.Element => {
   return (
     <>
-      <div {...props.label}>
-        <div>{info.label ? `${info.label}: ` : ""}</div>
-        <div>{info.variable ? `${info.variable}: ` : ""}</div>
-      </div>
-      <div {...props.value}>
-        <div>{info.name || ""}</div>
-        <div>
-          {info.value ? Math.round(info.value) : "N/A"}
-          {info.units ? info.units : ""}
-        </div>
-      </div>
+      <div {...props.title}>{info.title}</div>
+      {info.customTooltipData &&
+      Object.keys(JSON.parse(info.customTooltipData)).length > 0 ? (
+        Object.entries(JSON.parse(info.customTooltipData)).map(
+          ([key, value]) => {
+            return (
+              <div {...props.content}>
+                <div {...props.label}>{`${key}:` || ""}</div>
+                <div {...props.value}>{value || ""}</div>
+              </div>
+            )
+          }
+        )
+      ) : (
+        <>
+          <div {...props.content}>
+            <div {...props.label}>{info.label ? `${info.label}: ` : ""}</div>
+            <div {...props.value}>{info.name || ""}</div>
+          </div>
+          <div {...props.content}>
+            <div {...props.label}>
+              {info.variable ? `${info.variable}: ` : ""}
+            </div>
+            <div {...props.value}>
+              {Math.round(info.value) || "N/A"}
+              {info.units || ""}
+            </div>
+          </div>
+        </>
+      )}
       <span {...props.pointer}></span>
     </>
   )


### PR DESCRIPTION
- Implemented row flow on the tooltip content (label and value)
- To handle additional data, I allowed for customTooltipData object to be passed in the geojson, and map through the key,value.

Example:
```js
const geoData = guineaData.features.map((e) => ({
...e,
    properties: {
      ...e.properties,
      variable: "BCG",
      units: "%",
      label: "Region",
      customTooltipData: {
        Region: e.properties.name,
        Coverage: e.properties.value + e.properties.units,
      },
      title: e.properties.variable,
    },
  }))```